### PR TITLE
Add workflow id parameter to server tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,8 @@
 ```
 
 Use your MCP client (e.g., Claude Desktop) to call the `trigger`, `approve`,
-`reject`, and `status` tools. The sample invoice lives at
-`samples/invoice_acme.json`. Inspect Temporal Web at
-`http://localhost:8233`. Kill and restart the worker at any time to observe
-deterministic replay.
+`reject`, and `status` tools. The `trigger` tool now returns both the
+`workflow_id` and `run_id` of the started workflow. Pass these values to the
+`approve`, `reject`, and `status` tools. The sample invoice lives at
+`samples/invoice_acme.json`. Inspect Temporal Web at `http://localhost:8233`.
+Kill and restart the worker at any time to observe deterministic replay.

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ async def _client() -> Client:
 mcp = FastMCP("invoice_processor")
 
 @mcp.tool()
-async def trigger(invoice: Dict) -> str:
+async def trigger(invoice: Dict) -> Dict[str, str]:
     """Start the InvoiceWorkflow with the given invoice JSON."""
     client = await _client()
     handle = await client.start_workflow(
@@ -21,32 +21,32 @@ async def trigger(invoice: Dict) -> str:
         id=f"invoice-{uuid.uuid4()}",
         task_queue="invoice-task-queue",
     )
-    return handle.run_id
+    return {"workflow_id": handle.id, "run_id": handle.run_id}
 
 
 @mcp.tool()
-async def approve(run_id: str) -> str:
+async def approve(workflow_id: str, run_id: str) -> str:
     """Signal approval for the invoice workflow."""
     client = await _client()
-    handle = client.get_workflow_handle(workflow_id="", run_id=run_id)
+    handle = client.get_workflow_handle(workflow_id=workflow_id, run_id=run_id)
     await handle.signal("ApproveInvoice")
     return "APPROVED"
 
 
 @mcp.tool()
-async def reject(run_id: str) -> str:
+async def reject(workflow_id: str, run_id: str) -> str:
     """Signal rejection for the invoice workflow."""
     client = await _client()
-    handle = client.get_workflow_handle(workflow_id="", run_id=run_id)
+    handle = client.get_workflow_handle(workflow_id=workflow_id, run_id=run_id)
     await handle.signal("RejectInvoice")
     return "REJECTED"
 
 
 @mcp.tool()
-async def status(run_id: str) -> str:
+async def status(workflow_id: str, run_id: str) -> str:
     """Return current status of the workflow."""
     client = await _client()
-    handle = client.get_workflow_handle(workflow_id="", run_id=run_id)
+    handle = client.get_workflow_handle(workflow_id=workflow_id, run_id=run_id)
     desc = await handle.describe()
     return desc.status.name
 


### PR DESCRIPTION
## Summary
- return workflow_id alongside run_id when triggering a workflow
- require both workflow_id and run_id when approving, rejecting, or checking status
- document the new return values and parameters

## Testing
- `python3 -m py_compile server.py worker.py activities.py workflows.py`