### PR TITLE
Add prompt handlers for invoice approval

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Dict
+from typing import Dict, Any
 
 from mcp.server.fastmcp import FastMCP
 from temporalio.client import Client
@@ -16,12 +16,18 @@ mcp = FastMCP("invoice_processor")
 
 
 @mcp.prompt()
-async def process_invoice_prompt() -> str:
-    """Explain how to start processing an invoice."""
-    return (
-        "Call the 'process_invoice' tool with the invoice JSON to start the "
-        "workflow. You can use the sample in 'samples/invoice_acme.json'."
-    )
+async def process_invoice_prompt() -> Dict[str, Any]:
+    """Prompt the user to submit invoice JSON for processing."""
+    return {
+        "tool": "process_invoice",
+        "fields": [
+            {
+                "name": "invoice",
+                "type": "textarea",
+                "label": "Invoice JSON",
+            }
+        ],
+    }
 
 
 @mcp.tool()
@@ -35,6 +41,24 @@ async def process_invoice(invoice: Dict) -> Dict[str, str]:
         task_queue="invoice-task-queue",
     )
     return {"workflow_id": handle.id, "run_id": handle.result_run_id}
+
+
+@mcp.prompt()
+async def approve_invoice_prompt() -> str:
+    """Guide the user to approve a workflow."""
+    return (
+        "Call the 'approve_invoice' tool with the workflow_id and run_id to "
+        "approve the invoice."
+    )
+
+
+@mcp.prompt()
+async def reject_invoice_prompt() -> str:
+    """Guide the user to reject a workflow."""
+    return (
+        "Call the 'reject_invoice' tool with the workflow_id and run_id to "
+        "reject the invoice."
+    )
 
 
 @mcp.tool()

--- a/server.py
+++ b/server.py
@@ -15,6 +15,27 @@ async def _client() -> Client:
 mcp = FastMCP("invoice_processor")
 
 
+@mcp.prompt()
+async def approve_invoice_prompt(workflow_id: str, run_id: str) -> str:
+    """Request human approval for the given workflow."""
+    return (
+        f"Invoice workflow {workflow_id} is awaiting approval. "
+        f"If you wish to approve it call the 'approve_invoice' tool with"
+        f" workflow_id '{workflow_id}' and run_id '{run_id}'. "
+        f"To deny it instead use 'reject_invoice' with the same arguments."
+    )
+
+
+@mcp.prompt()
+async def deny_invoice_prompt(workflow_id: str, run_id: str) -> str:
+    """Request human denial for the given workflow."""
+    return (
+        f"Invoice workflow {workflow_id} can be denied by calling"
+        f" 'reject_invoice' with workflow_id '{workflow_id}' and run_id "
+        f"'{run_id}'. If you would rather approve, use 'approve_invoice'."
+    )
+
+
 @mcp.tool()
 async def process_invoice(invoice: Dict) -> Dict[str, str]:
     """Start the InvoiceWorkflow with the given invoice JSON."""

--- a/server.py
+++ b/server.py
@@ -16,23 +16,11 @@ mcp = FastMCP("invoice_processor")
 
 
 @mcp.prompt()
-async def approve_invoice_prompt(workflow_id: str, run_id: str) -> str:
-    """Request human approval for the given workflow."""
+async def process_invoice_prompt() -> str:
+    """Explain how to start processing an invoice."""
     return (
-        f"Invoice workflow {workflow_id} is awaiting approval. "
-        f"If you wish to approve it call the 'approve_invoice' tool with"
-        f" workflow_id '{workflow_id}' and run_id '{run_id}'. "
-        f"To deny it instead use 'reject_invoice' with the same arguments."
-    )
-
-
-@mcp.prompt()
-async def deny_invoice_prompt(workflow_id: str, run_id: str) -> str:
-    """Request human denial for the given workflow."""
-    return (
-        f"Invoice workflow {workflow_id} can be denied by calling"
-        f" 'reject_invoice' with workflow_id '{workflow_id}' and run_id "
-        f"'{run_id}'. If you would rather approve, use 'approve_invoice'."
+        "Call the 'process_invoice' tool with the invoice JSON to start the "
+        "workflow. You can use the sample in 'samples/invoice_acme.json'."
     )
 
 


### PR DESCRIPTION
## Summary
- implement `approve_invoice_prompt` and `deny_invoice_prompt`
- expose these as MCP prompts alongside the existing tools

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_6875e06386248330803f9e8e79087011